### PR TITLE
Add Data Ethics Policy (v1.0) — resolves #24

### DIFF
--- a/docs/data_ethics_policy.md
+++ b/docs/data_ethics_policy.md
@@ -1,0 +1,48 @@
+# Data Ethics Policy
+
+## 1. Purpose
+
+This policy defines how we ethically collect, use, share, and protect data contributed to the Sudanese-Arabic-LLM project. It ensures the rights and dignity of contributors are respected while enabling responsible research and model development.
+
+## 2. Scope
+
+This policy applies to all data contributions, including:
+- Annotated text
+- Audio recordings
+- Transcriptions
+- Cultural expressions (e.g., proverbs, poetry, folk stories)
+
+## 3. Contributor Consent
+
+- All contributors must provide informed consent prior to the collection or use of their data.
+- Consent must be explicit, via signed forms or digital checkboxes.
+- Contributors may withdraw their data at any time by contacting the project maintainers.
+
+## 4. Copyright and Licensing
+
+- Contributors retain copyright unless they choose to release content under an open license (e.g., CC BY 4.0).
+- By contributing, users grant the project a non-exclusive right to use their content for research, publication, and LLM training.
+- Redistribution of datasets will comply with the licensing terms specified by the contributor.
+
+## 5. Prohibited Content
+
+- No third-party copyrighted material without explicit permission.
+- No personally identifiable or sensitive information.
+- No data from minors without verified guardian consent.
+
+## 6. Use of Data and Scraping
+
+- Data scraping of contributions is permitted only within the project and must adhere to contributor permissions.
+- Public datasets will be reviewed and filtered to exclude unlicensed or withdrawn data.
+- All uses of data for model training must respect contributor consent.
+
+## 7. Transparency
+
+- This policy is version-controlled and publicly accessible.
+- Updates will be proposed via pull request and reviewed by project maintainers.
+
+## 8. Contact
+
+For data removal requests, questions, or concerns, please open an issue via:
+
+[GitHub Issues](https://github.com/AnwarCS/Sudanese-Arabic-LLM/issues).


### PR DESCRIPTION
This commit introduces a Data Ethics Policy for the Sudanese-Arabic-LLM project.  This document helps ensure responsible research practices and contributor protection in alignment with open-source data ethics norms and resolves #24  contributes to #11